### PR TITLE
luci-theme-bootstrap: Allways show scrollbar

### DIFF
--- a/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
+++ b/themes/luci-theme-bootstrap/htdocs/luci-static/bootstrap/cascade.css
@@ -288,6 +288,7 @@ body {
 	min-height: 100%;
 	display: flex;
 	flex-direction: column;
+	overflow-y: scroll;
 }
 
 .container {


### PR DESCRIPTION
With this addition to the body tag, on desktop browsers the vertical scrollbar
is always visible and the content will not be shifted by changing tabs (like
at System/Software when the update tab has no to little content).

I couldn't see any negative side effects with Chromium browsers or Firefox
under Windows/Linux and Android, but I don't have access to Apple devices
for tests.