### PR TITLE
luci-mod-status: persist sorting of Wi-Fi associated stations table

### DIFF
--- a/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
+++ b/modules/luci-mod-status/htdocs/luci-static/resources/view/status/include/60_wifi.js
@@ -227,7 +227,7 @@ return baseclass.extend({
 		if (!table.lastElementChild)
 			return null;
 
-		var assoclist = E('table', { 'class': 'table assoclist' }, [
+		var assoclist = E('table', { 'class': 'table assoclist', 'id': 'wifi_assoclist_table' }, [
 			E('tr', { 'class': 'tr table-titles' }, [
 				E('th', { 'class': 'th nowrap' }, _('Network')),
 				E('th', { 'class': 'th hide-xs' }, _('MAC address')),


### PR DESCRIPTION
Similar to commit 6039925 from @jow-

Add an ID attribute to the dynamically generated Wi-Fi associated stations table to persist row ordering choice across reloads.

At the luci-mod-network view, the Wi-Fi associated stations table already has the same id.